### PR TITLE
VTA-83: Switch to use dev version of gov notify

### DIFF
--- a/src/config/config.yml
+++ b/src/config/config.yml
@@ -30,4 +30,4 @@ invoke:
         name: activities-${BRANCH}
 notify:
   api_key:
-  templateId: 306d864b-a56d-49eb-b3cc-6d23cf8bcc26
+  templateId: 2af4ff8e-af5b-4f32-80a9-d03719180647

--- a/src/config/config.yml
+++ b/src/config/config.yml
@@ -30,3 +30,4 @@ invoke:
         name: activities-${BRANCH}
 notify:
   api_key:
+  templateId: 306d864b-a56d-49eb-b3cc-6d23cf8bcc26

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -84,6 +84,7 @@ interface IInvokeConfig {
 
 interface INotifyConfig {
   api_key: string;
+  templateId: string;
 }
 
 interface ISecretConfig {

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -1,5 +1,5 @@
-import {LambdaService} from "./LambdaService";
-import {ActivityService, ActivityType} from "./ActivityService";
+import { LambdaService } from "./LambdaService";
+import { ActivityService, ActivityType } from "./ActivityService";
 import Lambda = require("aws-sdk/clients/lambda");
 import { TestResultsService } from "./TestResultsService";
 import {

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -107,7 +107,8 @@ export class CleanupService {
       await this.notificationService.sendVisitExpiryNotifications(userDetails);
       await this.activityService.endActivities(closingActivityDetails);
       return Promise.resolve();
-    } catch (e) {
+    } catch (error) {
+      console.error(error);
       return Promise.reject();
     }
   }

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,30 +1,30 @@
 // @ts-ignore
 import { NotifyClient } from "notifications-node-client";
-import { TEMPLATE_IDS } from "../utils/Enums";
 import { ITesterDetails } from "../models";
 import HTTPError from "../models/HTTPError";
+import { Configuration } from "../utils/Configuration";
 
 /**
  * Service class for Certificate Notifications
  */
 class NotificationService {
   private readonly notifyClient: NotifyClient;
+  private readonly config: Configuration;
 
   constructor(notifyClient: NotifyClient) {
     this.notifyClient = notifyClient;
+    this.config = Configuration.getInstance();
   }
 
   /**
    * Send multiple emails based on array of user details
    * @param userDetails
    */
-  public sendVisitExpiryNotifications(userDetails: ITesterDetails[]) {
+  public async sendVisitExpiryNotifications(userDetails: ITesterDetails[]) {
+    const templateId: string = await this.config.getTemplateIdFromEV();
     const sendEmailPromise = [];
     for (const detail of userDetails) {
-      const sendEmail = this.notifyClient.sendEmail(
-        TEMPLATE_IDS.TESTER_VISIT_EXPIRY,
-        detail.email
-      );
+      const sendEmail = this.notifyClient.sendEmail(templateId, detail.email);
       sendEmailPromise.push(sendEmail);
     }
 

--- a/src/utils/Configuration.ts
+++ b/src/utils/Configuration.ts
@@ -100,7 +100,7 @@ class Configuration {
       throw new Error(ERRORS.NOTIFY_CONFIG_NOT_DEFINED);
     }
     if (!this.config.notify.api_key) {
-      this.config.notify = (await this.setSecrets()).notify;
+      this.config.notify = <INotifyConfig>(await this.setSecrets()).notify;
     }
 
     return this.config.notify;
@@ -122,6 +122,24 @@ class Configuration {
         : "remote";
 
     return this.config.invoke[env];
+  }
+
+  /**
+   * Retrieves the templateId from environment variable
+   */
+  public async getTemplateIdFromEV(): Promise<string> {
+    if (!process.env.BRANCH || process.env.BRANCH === "local") {
+      if (!this.config.notify.templateId) {
+        throw new Error(ERRORS.TEMPLATE_ID_ENV_VAR_NOT_EXIST);
+      } else {
+        return this.config.notify.templateId;
+      }
+    } else {
+      if (!process.env.TEMPLATE_ID) {
+        throw new Error(ERRORS.TEMPLATE_ID_ENV_VAR_NOT_EXIST);
+      }
+      return process.env.TEMPLATE_ID;
+    }
   }
 
   /**

--- a/src/utils/Configuration.ts
+++ b/src/utils/Configuration.ts
@@ -21,7 +21,7 @@ class Configuration {
   private readonly config: IConfig;
   private secretsClient: SecretsManager;
 
-  private constructor(configPath: string) {
+  constructor(configPath: string) {
     // @ts-ignore
     this.secretsClient = AWSXray.captureAWSClient(
       new SecretsManager({ region: "eu-west-1" })
@@ -125,7 +125,7 @@ class Configuration {
   }
 
   /**
-   * Retrieves the templateId from environment variable
+   * Retrieves the templateId from config file when running locally, else environment variable
    */
   public async getTemplateIdFromEV(): Promise<string> {
     if (!process.env.BRANCH || process.env.BRANCH === "local") {

--- a/src/utils/Configuration.ts
+++ b/src/utils/Configuration.ts
@@ -100,7 +100,7 @@ class Configuration {
       throw new Error(ERRORS.NOTIFY_CONFIG_NOT_DEFINED);
     }
     if (!this.config.notify.api_key) {
-      this.config.notify = <INotifyConfig>(await this.setSecrets()).notify;
+      this.config.notify = (await this.setSecrets()).notify as INotifyConfig;
     }
 
     return this.config.notify;

--- a/src/utils/Enums.ts
+++ b/src/utils/Enums.ts
@@ -13,12 +13,9 @@ export enum HTTPRESPONSE {
 export enum ERRORS {
   NO_BRANCH = "'BRANCH' environment variable not found",
   NOTIFY_CONFIG_NOT_DEFINED = "The Notify config is not defined in the config file.",
+  TEMPLATE_ID_ENV_VAR_NOT_EXIST = "TEMPLATE_ID environment variable does not exist.",
   SECRET_ENV_VAR_NOT_SET = "SECRET_NAME environment variable not set.",
   SECRET_STRING_EMPTY = "SecretString is empty.",
   GET_ACIVITY_FAILURE = "Get Activities encountered errors",
   END_ACIVITY_FAILURE = "Ending activities encountered failures",
-}
-
-export enum TEMPLATE_IDS {
-  TESTER_VISIT_EXPIRY = "72eac307-d001-4b13-9fde-9f26c631da68",
 }

--- a/tests/resources/badConfig.yml
+++ b/tests/resources/badConfig.yml
@@ -1,0 +1,2 @@
+notify:
+  templateId:

--- a/tests/unit/NotificationService.unitTest.ts
+++ b/tests/unit/NotificationService.unitTest.ts
@@ -1,5 +1,4 @@
 import { NotificationService } from "../../src/services/NotificationService";
-import { TEMPLATE_IDS } from "../../src/utils/Enums";
 import HTTPError from "../../src/models/HTTPError";
 
 describe("Notification Service", () => {
@@ -9,7 +8,7 @@ describe("Notification Service", () => {
   });
   describe("sendVisitExpiryNotifications", () => {
     describe("when passed an array of UserDetails", () => {
-      it("invokes sendNotification once per arrayItem, with correct Params", () => {
+      it("invokes sendNotification once per arrayItem, with correct Params", async () => {
         expect.assertions(3);
         const sendEmailSpy = jest.fn().mockResolvedValue("");
         const notifSpy = jest.fn().mockImplementation(() => {
@@ -19,13 +18,13 @@ describe("Notification Service", () => {
         });
 
         const svc = new NotificationService(new notifSpy());
-        svc.sendVisitExpiryNotifications([
+        await svc.sendVisitExpiryNotifications([
           { email: "abc123" },
           { email: "bcd234" },
         ]);
         expect(sendEmailSpy.mock.calls).toHaveLength(2);
         expect(sendEmailSpy.mock.calls[0][0]).toEqual(
-          TEMPLATE_IDS.TESTER_VISIT_EXPIRY
+          "306d864b-a56d-49eb-b3cc-6d23cf8bcc26"
         );
         expect(sendEmailSpy.mock.calls[0][1]).toEqual("abc123");
       });

--- a/tests/unit/NotificationService.unitTest.ts
+++ b/tests/unit/NotificationService.unitTest.ts
@@ -24,7 +24,7 @@ describe("Notification Service", () => {
         ]);
         expect(sendEmailSpy.mock.calls).toHaveLength(2);
         expect(sendEmailSpy.mock.calls[0][0]).toEqual(
-          "306d864b-a56d-49eb-b3cc-6d23cf8bcc26"
+          "2af4ff8e-af5b-4f32-80a9-d03719180647"
         );
         expect(sendEmailSpy.mock.calls[0][1]).toEqual("abc123");
       });

--- a/tests/unit/cleanupVisitsFunction.unitTest.ts
+++ b/tests/unit/cleanupVisitsFunction.unitTest.ts
@@ -9,7 +9,7 @@ describe("CleanupVisits function", () => {
   process.env.SECRET_NAME = "something";
   jest
     .spyOn(Configuration.prototype, "getNotifyConfig")
-    .mockResolvedValue({ api_key: "something" });
+    .mockResolvedValue({ api_key: "something", templateId: "something" });
 
   it("invokes the CleanupService's cleanupVisits function", async () => {
     const svcMock = jest.fn().mockResolvedValue("");

--- a/tests/unit/handler.unitTest.ts
+++ b/tests/unit/handler.unitTest.ts
@@ -19,7 +19,7 @@ describe("Handler", () => {
         .mockImplementation(cleanupVisits);
       jest
         .spyOn(Configuration.prototype, "getNotifyConfig")
-        .mockResolvedValue({ api_key: "something" });
+        .mockResolvedValue({ api_key: "something", templateId: "something" });
       const event = {
         details: {
           eventName: "cleanup",


### PR DESCRIPTION
## Switch scheduled-operations service to use dev version of gov notify

This piece of work was completed to switch the scheduled-operations service to use the dev gov notify account in non-prod environments.
[VTA-83](https://jira.dvsacloud.uk/browse/VTA-109)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
