### PR TITLE
feat(cb2-12694): Implement types-definition into scheduled-ops service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.554.0",
         "@aws-sdk/client-secrets-manager": "^3.554.0",
-        "@dvsa/cvs-type-definitions": "7.1.0",
+        "@dvsa/cvs-type-definitions": "7.2.0",
         "@smithy/util-utf8": "^2.3.0",
         "@types/js-yaml": "^3.12.2",
         "aws-xray-sdk": "^3.6.0",
@@ -2359,9 +2359,9 @@
       }
     },
     "node_modules/@dvsa/cvs-type-definitions": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.1.0.tgz",
-      "integrity": "sha512-zvuzyBNu30wmjo9vkjmXTokoy3Gvii9Sj7y+AmQeqe0fp1HbJRF27nu68n457VHyQf+rDQACIVvDksGVXY8Cqg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.2.0.tgz",
+      "integrity": "sha512-xgJ1WpIpKkUkKrCtle9OqDbnmpm9VZ8ePdl+QPvayRHxGpDgLTTgj9wyhsz9+XW2bqOepAGbBM1jO+JMPLZAog==",
       "dependencies": {
         "ajv": "^8.12.0",
         "json-schema-deref-sync": "^0.14.0",
@@ -19179,9 +19179,9 @@
       }
     },
     "@dvsa/cvs-type-definitions": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.1.0.tgz",
-      "integrity": "sha512-zvuzyBNu30wmjo9vkjmXTokoy3Gvii9Sj7y+AmQeqe0fp1HbJRF27nu68n457VHyQf+rDQACIVvDksGVXY8Cqg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.2.0.tgz",
+      "integrity": "sha512-xgJ1WpIpKkUkKrCtle9OqDbnmpm9VZ8ePdl+QPvayRHxGpDgLTTgj9wyhsz9+XW2bqOepAGbBM1jO+JMPLZAog==",
       "requires": {
         "ajv": "^8.12.0",
         "json-schema-deref-sync": "^0.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.554.0",
         "@aws-sdk/client-secrets-manager": "^3.554.0",
+        "@dvsa/cvs-type-definitions": "7.1.0",
         "@smithy/util-utf8": "^2.3.0",
         "@types/js-yaml": "^3.12.2",
         "aws-xray-sdk": "^3.6.0",
@@ -2356,6 +2357,37 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@dvsa/cvs-type-definitions": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.1.0.tgz",
+      "integrity": "sha512-zvuzyBNu30wmjo9vkjmXTokoy3Gvii9Sj7y+AmQeqe0fp1HbJRF27nu68n457VHyQf+rDQACIVvDksGVXY8Cqg==",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "json-schema-deref-sync": "^0.14.0",
+        "pretty-js": "^0.2.2",
+        "util": "^0.12.5"
+      }
+    },
+    "node_modules/@dvsa/cvs-type-definitions/node_modules/ajv": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+      "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@dvsa/cvs-type-definitions/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@hapi/accept": {
       "version": "6.0.3",
@@ -6230,6 +6262,14 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/child-process-ext": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/child-process-ext/-/child-process-ext-2.1.1.tgz",
@@ -6621,6 +6661,19 @@
         "dot-prop": "^5.1.0"
       }
     },
+    "node_modules/complexion": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/complexion/-/complexion-0.2.2.tgz",
+      "integrity": "sha512-YAfDsYc27CsPQPzZU4i1OklMCyigN7VHPylWba0AWf5VmVr34NpLhHjJm0gumFh9m2aX8fYGCTTgne7oLfXXug=="
+    },
+    "node_modules/complexion-js": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/complexion-js/-/complexion-js-0.2.2.tgz",
+      "integrity": "sha512-qxqJq0nEBwSEZtoqK8bHIR2VwzbPatjtlU+ZH9IPObitTQqa2xMEryoAlCsjOH+ATgIScHt0aiCUBabPG2Mmcg==",
+      "peerDependencies": {
+        "complexion": "^0.2.2"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -6985,6 +7038,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/d": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
@@ -6997,6 +7058,11 @@
       "engines": {
         "node": ">=0.12"
       }
+    },
+    "node_modules/dag-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
+      "integrity": "sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw=="
     },
     "node_modules/dargs": {
       "version": "7.0.0",
@@ -9756,7 +9822,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -9824,6 +9889,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -9914,7 +9984,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -9943,6 +10012,36 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==",
+      "dependencies": {
+        "is-glob": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-invalid-path/node_modules/is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-invalid-path/node_modules/is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+      "dependencies": {
+        "is-extglob": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-natural-number": {
@@ -10108,6 +10207,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==",
+      "dependencies": {
+        "is-invalid-path": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-weakref": {
@@ -11315,6 +11425,32 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/json-schema-deref-sync": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.14.0.tgz",
+      "integrity": "sha512-yGR1xmhdiD6R0MSrwWcFxQzAj5b3i5Gb/mt5tvQKgFMMeNe0KZYNEN/jWr7G+xn39Azqgcvk4ZKMs8dQl8e4wA==",
+      "dependencies": {
+        "clone": "^2.1.2",
+        "dag-map": "~1.0.0",
+        "is-valid-path": "^0.1.1",
+        "lodash": "^4.17.13",
+        "md5": "~2.2.0",
+        "memory-cache": "~0.2.0",
+        "traverse": "~0.6.6",
+        "valid-url": "~1.0.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/json-schema-deref-sync/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -12007,6 +12143,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha512-PlGG4z5mBANDGCKsYQe0CaUYHdZYZt8ZPZLmEt+Urf0W4GlpTX4HescwHU+dc9+Z/G/vZKYZYFrwgm9VxK6QOQ==",
+      "dependencies": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
     "node_modules/mem": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -12045,6 +12191,11 @@
         "next-tick": "^1.1.0",
         "timers-ext": "^0.1.7"
       }
+    },
+    "node_modules/memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA=="
     },
     "node_modules/meow": {
       "version": "8.1.2",
@@ -12721,6 +12872,11 @@
         "opencollective-postinstall": "index.js"
       }
     },
+    "node_modules/option-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/option-parser/-/option-parser-1.0.2.tgz",
+      "integrity": "sha512-Q56FmRi6TZX+S9jAl9f0Tnrk7W8faAZULf6Y0IgJR6Cy7/MxhzvBFoyL1Sz2DD7WbOY2Fxtkz2S/3kzlbn/VsQ=="
+    },
     "node_modules/optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -13386,6 +13542,25 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-js": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/pretty-js/-/pretty-js-0.2.2.tgz",
+      "integrity": "sha512-SJIz4tGlSC4LBqSAb82yf1911C4HGILMiDoNn4aoYuHetdFbefdIyMHZ9c1mDsiv0CNSn9ac/kNM1xXdujZ/AA==",
+      "dependencies": {
+        "complexion": "^0.2.2",
+        "complexion-js": "^0.2.2",
+        "option-parser": "^1.0.0",
+        "process-files": "^1.0.0"
+      },
+      "bin": {
+        "pretty-js": "bin/pretty-js.js"
+      }
+    },
+    "node_modules/process-files": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-files/-/process-files-1.0.0.tgz",
+      "integrity": "sha512-0hxz8bXkV3zO9yi5gausGcagj6iaUK4cZsK9OeL8ekVWkXuD0SC/1iE1cJntRxFWGNpZCc/hjYhc7XCwz8WuWQ=="
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -13812,7 +13987,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15967,7 +16141,6 @@
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
       "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -16546,7 +16719,6 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -16591,6 +16763,11 @@
       "engines": {
         "node": ">=10.12.0"
       }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -18998,6 +19175,35 @@
             "@jridgewell/resolve-uri": "^3.0.3",
             "@jridgewell/sourcemap-codec": "^1.4.10"
           }
+        }
+      }
+    },
+    "@dvsa/cvs-type-definitions": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/cvs-type-definitions/-/cvs-type-definitions-7.1.0.tgz",
+      "integrity": "sha512-zvuzyBNu30wmjo9vkjmXTokoy3Gvii9Sj7y+AmQeqe0fp1HbJRF27nu68n457VHyQf+rDQACIVvDksGVXY8Cqg==",
+      "requires": {
+        "ajv": "^8.12.0",
+        "json-schema-deref-sync": "^0.14.0",
+        "pretty-js": "^0.2.2",
+        "util": "^0.12.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.16.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+          "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.4.1"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },
@@ -22096,6 +22302,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+    },
     "child-process-ext": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/child-process-ext/-/child-process-ext-2.1.1.tgz",
@@ -22404,6 +22615,17 @@
         "dot-prop": "^5.1.0"
       }
     },
+    "complexion": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/complexion/-/complexion-0.2.2.tgz",
+      "integrity": "sha512-YAfDsYc27CsPQPzZU4i1OklMCyigN7VHPylWba0AWf5VmVr34NpLhHjJm0gumFh9m2aX8fYGCTTgne7oLfXXug=="
+    },
+    "complexion-js": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/complexion-js/-/complexion-js-0.2.2.tgz",
+      "integrity": "sha512-qxqJq0nEBwSEZtoqK8bHIR2VwzbPatjtlU+ZH9IPObitTQqa2xMEryoAlCsjOH+ATgIScHt0aiCUBabPG2Mmcg==",
+      "requires": {}
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -22658,6 +22880,11 @@
         "which": "^2.0.1"
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
+    },
     "d": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
@@ -22667,6 +22894,11 @@
         "es5-ext": "^0.10.64",
         "type": "^2.7.2"
       }
+    },
+    "dag-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
+      "integrity": "sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw=="
     },
     "dargs": {
       "version": "7.0.0",
@@ -24786,7 +25018,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
       "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -24833,6 +25064,11 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.2.7",
@@ -24887,7 +25123,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
       "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -24905,6 +25140,29 @@
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true
+    },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==",
+      "requires": {
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww=="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
     },
     "is-natural-number": {
       "version": "4.0.1",
@@ -25010,6 +25268,14 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
+    },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==",
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -25913,6 +26179,28 @@
         "uri-js": "^4.2.2"
       }
     },
+    "json-schema-deref-sync": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.14.0.tgz",
+      "integrity": "sha512-yGR1xmhdiD6R0MSrwWcFxQzAj5b3i5Gb/mt5tvQKgFMMeNe0KZYNEN/jWr7G+xn39Azqgcvk4ZKMs8dQl8e4wA==",
+      "requires": {
+        "clone": "^2.1.2",
+        "dag-map": "~1.0.0",
+        "is-valid-path": "^0.1.1",
+        "lodash": "^4.17.13",
+        "md5": "~2.2.0",
+        "memory-cache": "~0.2.0",
+        "traverse": "~0.6.6",
+        "valid-url": "~1.0.9"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+        }
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -26494,6 +26782,16 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha512-PlGG4z5mBANDGCKsYQe0CaUYHdZYZt8ZPZLmEt+Urf0W4GlpTX4HescwHU+dc9+Z/G/vZKYZYFrwgm9VxK6QOQ==",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
     "mem": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -26528,6 +26826,11 @@
         "next-tick": "^1.1.0",
         "timers-ext": "^0.1.7"
       }
+    },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA=="
     },
     "meow": {
       "version": "8.1.2",
@@ -27040,6 +27343,11 @@
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
       "dev": true
     },
+    "option-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/option-parser/-/option-parser-1.0.2.tgz",
+      "integrity": "sha512-Q56FmRi6TZX+S9jAl9f0Tnrk7W8faAZULf6Y0IgJR6Cy7/MxhzvBFoyL1Sz2DD7WbOY2Fxtkz2S/3kzlbn/VsQ=="
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -27514,6 +27822,22 @@
         }
       }
     },
+    "pretty-js": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/pretty-js/-/pretty-js-0.2.2.tgz",
+      "integrity": "sha512-SJIz4tGlSC4LBqSAb82yf1911C4HGILMiDoNn4aoYuHetdFbefdIyMHZ9c1mDsiv0CNSn9ac/kNM1xXdujZ/AA==",
+      "requires": {
+        "complexion": "^0.2.2",
+        "complexion-js": "^0.2.2",
+        "option-parser": "^1.0.0",
+        "process-files": "^1.0.0"
+      }
+    },
+    "process-files": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-files/-/process-files-1.0.0.tgz",
+      "integrity": "sha512-0hxz8bXkV3zO9yi5gausGcagj6iaUK4cZsK9OeL8ekVWkXuD0SC/1iE1cJntRxFWGNpZCc/hjYhc7XCwz8WuWQ=="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -27828,8 +28152,7 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "resolve": {
       "version": "1.22.4",
@@ -29491,8 +29814,7 @@
     "traverse": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
-      "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
-      "dev": true
+      "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA=="
     },
     "trim-newlines": {
       "version": "3.0.1",
@@ -29899,7 +30221,6 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -29937,6 +30258,11 @@
         "@types/istanbul-lib-coverage": "^2.0.1",
         "convert-source-map": "^2.0.0"
       }
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
+    "@dvsa/cvs-type-definitions": "7.1.0",
     "@aws-sdk/client-lambda": "^3.554.0",
     "@aws-sdk/client-secrets-manager": "^3.554.0",
     "@smithy/util-utf8": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@dvsa/cvs-type-definitions": "7.1.0",
+    "@dvsa/cvs-type-definitions": "7.2.0",
     "@aws-sdk/client-lambda": "^3.554.0",
     "@aws-sdk/client-secrets-manager": "^3.554.0",
     "@smithy/util-utf8": "^2.3.0",

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -10,62 +10,6 @@ interface IActivityParams {
   isOpen?: boolean;
 }
 
-interface IActivity {
-  id: string;
-  activityType: string;
-  testStationName?: string;
-  testStationPNumber?: string;
-  testStationEmail?: string;
-  testStationType?: string;
-  testerName: string;
-  testerEmail: string;
-  testerStaffId: string;
-  startTime: string;
-  endTime: string | null;
-  waitReason?: [string];
-  notes?: string;
-}
-
-export interface ITestResult {
-  testResultId: string;
-  systemNumber: string;
-  testerStaffId: string;
-  testStartTimestamp: string;
-  odometerReadingUnits: string;
-  testEndTimestamp: string;
-  testStatus: string;
-  testTypes: any[];
-  vehicleClass: IVehicleClass;
-  vin: string;
-  vehicleSize?: string; // Mandatory for PSV only & not applicable to HGV and TRL
-  testStationName: string;
-  vehicleId?: string; // Not sent from FE, calculated in the BE. When the test result is submitted, in BE, the VRM of the vehicle will be copied into  vehicleId also.
-  vehicleType: string;
-  countryOfRegistration: string;
-  preparerId: string;
-  preparerName: string;
-  odometerReading: number;
-  vehicleConfiguration: string;
-  testStationType: string;
-  reasonForCancellation: string | null;
-  testerName: string;
-  vrm?: string; // Mandatory for PSV and HGV, not applicable to TRL
-  testStationPNumber: string;
-  numberOfSeats?: number; // mandatory for PSV only, not applicable for HGV and TRL
-  noOfAxles: number;
-  testerEmailAddress: string;
-  euVehicleCategory: string;
-  deletionFlag: boolean | null; // Not sent from FE, calculated in the BE.
-  regnDate?: Date; // Used only for PSV and HGV
-  trailerId?: string; // Mandatory for TRL, not applicable to PSV and HGV
-  firstUseDate?: Date; // Used only for TRL
-}
-
-export interface IVehicleClass {
-  code: string;
-  description: string;
-}
-
 interface IFunctionEvent {
   name: string;
   path: string;
@@ -126,7 +70,6 @@ export interface ISubSeg {
 
 export {
   IActivityParams,
-  IActivity,
   IInvokeConfig,
   IFunctionEvent,
   INotifyConfig,

--- a/src/services/ActivityService.ts
+++ b/src/services/ActivityService.ts
@@ -3,10 +3,11 @@ import { InvocationRequest, InvokeCommandOutput } from '@aws-sdk/client-lambda';
 import { toUint8Array } from '@smithy/util-utf8';
 import { LambdaService } from './LambdaService';
 import { Configuration } from '../utils/Configuration';
-import { ACTIVITY_TYPE, ERRORS } from '../utils/Enums';
+import { ERRORS } from '../utils/Enums';
 import { IActivityParams, IInvokeConfig } from '../models';
 import { validateInvocationResponse } from '../utils/validateInvocationResponse';
 import { ActivitySchema } from "@dvsa/cvs-type-definitions/types/v1/activity";
+import { ActivityType } from "@dvsa/cvs-type-definitions/types/v1/enums/activityType.enum";
 import HTTPError from '../models/HTTPError';
 
 class ActivityService {
@@ -25,7 +26,7 @@ class ActivityService {
    * @param testerStaffId Tester Staff Id
    */
   public async getActivitiesList(
-    activityType: ACTIVITY_TYPE,
+    activityType: ActivityType,
     visitStartTime: string,
     testerStaffId?: string,
   ): Promise<ActivitySchema[]> {
@@ -34,7 +35,7 @@ class ActivityService {
     let params: IActivityParams;
 
     // Get all open visits, from 2020-01-01
-    if (activityType === ACTIVITY_TYPE.VISIT) {
+    if (activityType === ActivityType.VISIT) {
       params = {
         fromStartTime: defaultStartTime,
         toStartTime: today,
@@ -78,7 +79,7 @@ class ActivityService {
       if (payload) {
         console.log(`After validation - ${params.activityType}: `, payload);
       } else {
-        params.activityType === ACTIVITY_TYPE.VISIT
+        params.activityType === ActivityType.VISIT
           ? console.log(`No ${params.activityType} activities returned`)
           : console.log(`No ${params.activityType} activities returned for tester staff id - ${params.testerStaffId}`);
       }

--- a/src/services/ActivityService.ts
+++ b/src/services/ActivityService.ts
@@ -4,8 +4,9 @@ import { toUint8Array } from '@smithy/util-utf8';
 import { LambdaService } from './LambdaService';
 import { Configuration } from '../utils/Configuration';
 import { ACTIVITY_TYPE, ERRORS } from '../utils/Enums';
-import { IActivity, IActivityParams, IInvokeConfig } from '../models';
+import { IActivityParams, IInvokeConfig } from '../models';
 import { validateInvocationResponse } from '../utils/validateInvocationResponse';
+import { ActivitySchema } from "@dvsa/cvs-type-definitions/types/v1/activity";
 import HTTPError from '../models/HTTPError';
 
 class ActivityService {
@@ -27,7 +28,7 @@ class ActivityService {
     activityType: ACTIVITY_TYPE,
     visitStartTime: string,
     testerStaffId?: string,
-  ): Promise<IActivity[]> {
+  ): Promise<ActivitySchema[]> {
     const defaultStartTime: string = new Date(2020, 0, 1).toISOString();
     const today: string = new Date().toISOString();
     let params: IActivityParams;
@@ -57,7 +58,7 @@ class ActivityService {
    * Invoke the Activities service endpoint to get records based on the provided parameters
    * @param params - getActivities query parameters
    */
-  public async getActivities(params: IActivityParams): Promise<IActivity[]> {
+  public async getActivities(params: IActivityParams): Promise<ActivitySchema[]> {
     const config: IInvokeConfig = this.config.getInvokeConfig();
     const invokeParams: InvocationRequest = {
       FunctionName: config.functions.activities.name,

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -2,11 +2,13 @@ import { LambdaService } from './LambdaService';
 import { ActivityService } from './ActivityService';
 import { LambdaClient } from '@aws-sdk/client-lambda';
 import { TestResultsService } from './TestResultsService';
-import { IActivity, ILogVisit, ITestResult } from '../models';
+import { ILogVisit } from '../models';
 import { ACTIVITY_TYPE, HTTPRESPONSE, LOG_ACTIONS, LOG_REASONS, LOG_STATUS, TIMES } from '../utils/Enums';
 import { NotificationService } from './NotificationService';
-import HTTPResponse from '../models/HTTPResponse';
+import { ActivitySchema } from "@dvsa/cvs-type-definitions/types/v1/activity";
+import { TestResultSchema } from "@dvsa/cvs-type-definitions/types/v1/test";
 import { subHours } from 'date-fns';
+import HTTPResponse from '../models/HTTPResponse';
 import moment from 'moment';
 
 export class CleanupService {
@@ -30,10 +32,10 @@ export class CleanupService {
 
     try {
       // This goes to get all the open visits
-      const openVisits: IActivity[] = await this.activityService.getActivitiesList(ACTIVITY_TYPE.VISIT, '');
-      const actionVisits: IActivity[] = [];
-      let activities: IActivity[] = [];
-      let testResults: ITestResult[] = [];
+      const openVisits: ActivitySchema[] = await this.activityService.getActivitiesList(ACTIVITY_TYPE.VISIT, '');
+      const actionVisits: ActivitySchema[] = [];
+      let activities: ActivitySchema[] = [];
+      let testResults: TestResultSchema[] = [];
 
       // No open visits, log message, return and stop process
       if (openVisits.length === 0) {
@@ -46,7 +48,7 @@ export class CleanupService {
         if (moment(new Date(visit.startTime)).isAfter(recentActivityWindowTime)) {
           // Visit open less than 3 hours, no action needed
           this.addToLogVisits(
-            visit.id,
+            visit.id!,
             visit.testerStaffId,
             visit.startTime,
             visit.startTime,
@@ -98,9 +100,9 @@ export class CleanupService {
         if (moment(new Date(lastActionTime)).isBefore(terminationWindowTime)) {
           // last action time is more than 4 hours ago, close the visit
           try {
-            await this.activityService.endVisit(visit.id, lastActionTime);
+            await this.activityService.endVisit(visit.id!, lastActionTime);
             this.addToLogVisits(
-              visit.id,
+              visit.id!,
               visit.testerStaffId,
               visit.startTime,
               lastActionTime,
@@ -110,7 +112,7 @@ export class CleanupService {
             );
           } catch (e) {
             this.addToLogVisits(
-              visit.id,
+              visit.id!,
               visit.testerStaffId,
               visit.startTime,
               lastActionTime,
@@ -125,7 +127,7 @@ export class CleanupService {
           try {
             await this.notificationService.sendVisitExpiryNotification(visit);
             this.addToLogVisits(
-              visit.id,
+              visit.id!,
               visit.testerStaffId,
               visit.startTime,
               lastActionTime,
@@ -135,7 +137,7 @@ export class CleanupService {
             );
           } catch (e) {
             this.addToLogVisits(
-              visit.id,
+              visit.id!,
               visit.testerStaffId,
               visit.startTime,
               lastActionTime,
@@ -148,7 +150,7 @@ export class CleanupService {
         } else {
           // last action time under 3 hours, no action required
           this.addToLogVisits(
-            visit.id,
+            visit.id!,
             visit.testerStaffId,
             visit.startTime,
             lastActionTime,

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -3,10 +3,11 @@ import { ActivityService } from './ActivityService';
 import { LambdaClient } from '@aws-sdk/client-lambda';
 import { TestResultsService } from './TestResultsService';
 import { ILogVisit } from '../models';
-import { ACTIVITY_TYPE, HTTPRESPONSE, LOG_ACTIONS, LOG_REASONS, LOG_STATUS, TIMES } from '../utils/Enums';
+import { HTTPRESPONSE, LOG_ACTIONS, LOG_REASONS, LOG_STATUS, TIMES } from '../utils/Enums';
 import { NotificationService } from './NotificationService';
 import { ActivitySchema } from "@dvsa/cvs-type-definitions/types/v1/activity";
 import { TestResultSchema } from "@dvsa/cvs-type-definitions/types/v1/test";
+import { ActivityType } from "@dvsa/cvs-type-definitions/types/v1/enums/activityType.enum";
 import { subHours } from 'date-fns';
 import HTTPResponse from '../models/HTTPResponse';
 import moment from 'moment';
@@ -32,7 +33,7 @@ export class CleanupService {
 
     try {
       // This goes to get all the open visits
-      const openVisits: ActivitySchema[] = await this.activityService.getActivitiesList(ACTIVITY_TYPE.VISIT, '');
+      const openVisits: ActivitySchema[] = await this.activityService.getActivitiesList(ActivityType.VISIT, '');
       const actionVisits: ActivitySchema[] = [];
       let activities: ActivitySchema[] = [];
       let testResults: TestResultSchema[] = [];
@@ -75,9 +76,9 @@ export class CleanupService {
 
         // Get wait and unaccountable times for this visit
         activities = [
-          ...(await this.activityService.getActivitiesList(ACTIVITY_TYPE.WAIT, visit.startTime, visit.testerStaffId)),
+          ...(await this.activityService.getActivitiesList(ActivityType.WAIT, visit.startTime, visit.testerStaffId)),
           ...(await this.activityService.getActivitiesList(
-            ACTIVITY_TYPE.UNACCOUNTABLE_TIME,
+              ActivityType.UNACCOUNTABLE_TIME,
             visit.startTime,
             visit.testerStaffId,
           )),

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import { NotifyClient } from 'notifications-node-client';
-import { IActivity } from '../models';
 import { Configuration } from '../utils/Configuration';
+import { ActivitySchema } from "@dvsa/cvs-type-definitions/types/v1/activity";
 
 /**
  * Service class for Notifications
@@ -19,7 +19,7 @@ class NotificationService {
    * Send email to the tester with the details of the visit
    * @param visit
    */
-  async sendVisitExpiryNotification(visit: IActivity) {
+  async sendVisitExpiryNotification(visit: ActivitySchema) {
     const templateId: string = await this.config.getTemplateIdFromEV();
     return this.notifyClient.sendEmail(templateId, visit.testerEmail);
   }

--- a/src/services/TestResultsService.ts
+++ b/src/services/TestResultsService.ts
@@ -1,10 +1,11 @@
-import { IInvokeConfig, ITestResult } from '../models';
+import { IInvokeConfig } from '../models';
 import { ServiceException } from '@smithy/smithy-client';
 import { InvocationRequest, InvokeCommandOutput } from '@aws-sdk/client-lambda';
 import { toUint8Array } from '@smithy/util-utf8';
 import { LambdaService } from './LambdaService';
 import { Configuration } from '../utils/Configuration';
 import { validateInvocationResponse } from '../utils/validateInvocationResponse';
+import { TestResultSchema } from "@dvsa/cvs-type-definitions/types/v1/test";
 
 class TestResultsService {
   private readonly lambdaClient: LambdaService;
@@ -23,7 +24,7 @@ class TestResultsService {
   public async getRecentTestResultsByTesterStaffId(
     testerStaffId: string,
     visitStartTime: string,
-  ): Promise<ITestResult[]> {
+  ): Promise<TestResultSchema[]> {
     const params = {
       testerStaffId,
       fromDateTime: visitStartTime,
@@ -36,7 +37,7 @@ class TestResultsService {
    * Invoke the Test Result service endpoint to get test results based on the provided parameters
    * @param params - getTestResultsByTesterStaffId query parameters
    */
-  async getTestResults(params: any): Promise<ITestResult[]> {
+  async getTestResults(params: any): Promise<TestResultSchema[]> {
     const config: IInvokeConfig = this.config.getInvokeConfig();
     const invokeParams: InvocationRequest = {
       FunctionName: config.functions.testResults.name,

--- a/src/utils/Enums.ts
+++ b/src/utils/Enums.ts
@@ -38,9 +38,3 @@ export enum LOG_ACTIONS {
   NOTIFY = 'NOTIFY',
   CLOSE = 'CLOSE',
 }
-
-export enum ACTIVITY_TYPE {
-  VISIT = 'visit',
-  WAIT = 'wait',
-  UNACCOUNTABLE_TIME = 'unaccountable time',
-}

--- a/tests/resources/testTestResults.json
+++ b/tests/resources/testTestResults.json
@@ -27,7 +27,8 @@
     "noOfAxles": 5,
     "testerEmailAddress": "test@test.com",
     "euVehicleCategory": "m1",
-    "deletionFlag": null
+    "deletionFlag": null,
+    "numberOfWheelsDriven": 4
   },
   {
     "testResultId": "abc124",
@@ -57,7 +58,8 @@
     "noOfAxles": 5,
     "testerEmailAddress": "test@test.com",
     "euVehicleCategory": "m1",
-    "deletionFlag": null
+    "deletionFlag": null,
+    "numberOfWheelsDriven": 4
   },
   {
     "testResultId": "abc125",
@@ -87,6 +89,7 @@
     "noOfAxles": 5,
     "testerEmailAddress": "test@test.com",
     "euVehicleCategory": "m1",
-    "deletionFlag": null
+    "deletionFlag": null,
+    "numberOfWheelsDriven": 4
   }
 ]

--- a/tests/unit/CleanupService.unitTest.ts
+++ b/tests/unit/CleanupService.unitTest.ts
@@ -4,12 +4,12 @@ import activities from '../resources/testActivities.json';
 import testResults from '../resources/testTestResults.json';
 import { TestResultsService } from '../../src/services/TestResultsService';
 import { cloneDeep } from 'lodash';
-import { IActivity } from '../../src/models';
 import dateMock from '../util/dateMockUtils';
 import { ERRORS, HTTPRESPONSE } from '../../src/utils/Enums';
 import { subMinutes } from 'date-fns';
 import { NotificationService } from '../../src/services/NotificationService';
 import HTTPError from '../../src/models/HTTPError';
+import {ActivitySchema} from "@dvsa/cvs-type-definitions/types/v1/activity";
 
 jest.mock('../../src/services/ActivityService');
 
@@ -34,7 +34,7 @@ describe('Cleanup Service', () => {
   describe('With a visit deserving of no action', () => {
     it("returns 200 ok, with 'nothing to do' message", async () => {
       expect.assertions(2);
-      const allActivities: IActivity[] = cloneDeep([activities[0]]);
+      const allActivities: ActivitySchema[] = cloneDeep([activities[0]] as ActivitySchema[]);
       const freshActivities = allActivities.map((a) => {
         a.startTime = new Date().toISOString();
         a.endTime = null;
@@ -50,7 +50,7 @@ describe('Cleanup Service', () => {
     it("returns 200 ok, with 'nothing to do' message after processing activities that required no action", async () => {
       jest.resetAllMocks();
       console.log = jest.fn();
-      const allActivities: IActivity[] = cloneDeep(activities);
+      const allActivities: ActivitySchema[] = cloneDeep(activities) as ActivitySchema[];
       allActivities[0].startTime = new Date(subMinutes(new Date(), 240)).toISOString();
       allActivities[3].endTime = null;
       allActivities[4].endTime = new Date(subMinutes(new Date(), 30)).toISOString();
@@ -78,7 +78,7 @@ describe('Cleanup Service', () => {
           sendVisitExpiryNotifications: sendNotifyMock,
         };
       });
-      const allActivities: IActivity[] = cloneDeep([activities[0]]);
+      const allActivities: ActivitySchema[] = cloneDeep([activities[0]] as ActivitySchema[]);
       const staleActivities = allActivities.map((a) => {
         a.endTime = null;
         return a;
@@ -105,7 +105,7 @@ describe('Cleanup Service', () => {
           sendVisitExpiryNotifications: sendNotifyMock,
         };
       });
-      const allActivities: IActivity[] = cloneDeep([activities[0]]);
+      const allActivities: ActivitySchema[] = cloneDeep([activities[0]] as ActivitySchema[]);
       const staleActivities = allActivities.map((a) => {
         a.endTime = null;
         return a;
@@ -130,7 +130,7 @@ describe('Cleanup Service', () => {
           sendVisitExpiryNotifications: sendNotifyMock,
         };
       });
-      const allActivities: IActivity[] = cloneDeep([activities[0]]);
+      const allActivities: ActivitySchema[] = cloneDeep([activities[0] as ActivitySchema]);
       const staleActivities = allActivities.map((a) => {
         a.endTime = null;
         return a;
@@ -155,7 +155,7 @@ describe('Cleanup Service', () => {
     it('correctly tries to send the notification', async () => {
       jest.resetAllMocks();
       console.log = jest.fn();
-      const allActivities: IActivity[] = cloneDeep(activities);
+      const allActivities: ActivitySchema[] = cloneDeep(activities) as ActivitySchema[];
       allActivities[3].startTime = new Date(subMinutes(new Date(), 240)).toISOString();
       allActivities[3].endTime = null;
       allActivities[4].endTime = new Date(subMinutes(new Date(), 210)).toISOString();
@@ -182,7 +182,7 @@ describe('Cleanup Service', () => {
           sendVisitExpiryNotifications: sendNotifyMock,
         };
       });
-      const allActivities: IActivity[] = cloneDeep(activities);
+      const allActivities: ActivitySchema[] = cloneDeep(activities) as ActivitySchema[];
       allActivities[3].startTime = new Date(subMinutes(new Date(), 240)).toISOString();
       allActivities[3].endTime = null;
       allActivities[4].endTime = new Date(subMinutes(new Date(), 210)).toISOString();

--- a/tests/unit/NotificationService.unitTest.ts
+++ b/tests/unit/NotificationService.unitTest.ts
@@ -1,6 +1,8 @@
 import { NotificationService } from '../../src/services/NotificationService';
 import HTTPError from '../../src/models/HTTPError';
-import { IActivity } from '../../src/models';
+import { ActivitySchema } from "@dvsa/cvs-type-definitions/types/v1/activity";
+import { TestStationTypes } from "@dvsa/cvs-type-definitions/types/v1/enums/testStationType.enum";
+import { ActivityType } from "@dvsa/cvs-type-definitions/types/v1/enums/activityType.enum";
 
 describe('Notification Service', () => {
   afterEach(() => {
@@ -8,14 +10,18 @@ describe('Notification Service', () => {
     jest.restoreAllMocks();
   });
   describe('sendVisitExpiryNotifications', () => {
-    const visit: IActivity = {
+    const visit: ActivitySchema = {
       id: '123',
-      activityType: 'visit',
+      activityType: ActivityType.VISIT,
       testerName: 'Tester1',
       testerStaffId: '123456',
       testerEmail: 'test1@test.com',
       startTime: '2022-01-01T12:00:45.938Z',
       endTime: null,
+      testStationEmail: "some.name@dvsatest.co.uk",
+      testStationName: "Some Name",
+      testStationPNumber: "P123",
+      testStationType: TestStationTypes.ATF,
     };
     describe('when passed an array of UserDetails', () => {
       it('invokes sendNotification once per arrayItem, with correct Params', async () => {

--- a/tests/unit/TestResultsService.unitTest.ts
+++ b/tests/unit/TestResultsService.unitTest.ts
@@ -1,8 +1,8 @@
 import { TestResultsService } from '../../src/services/TestResultsService';
 import testResults from '../resources/testTestResults.json';
-import { ITestResult } from '../../src/models';
 import trResponse from '../resources/testResults-response.json';
 import { cloneDeep } from 'lodash';
+import {TestResultSchema} from "@dvsa/cvs-type-definitions/types/v1/test";
 
 describe('Test Results Service', () => {
   beforeEach(() => {
@@ -21,9 +21,9 @@ describe('Test Results Service', () => {
     describe('when all testers have recent results', () => {
       it('should call getTestResults once per staffId, with correct params, and return a list of recent test results for each testerId', async () => {
         const getTestResultsSpy = jest.spyOn(TestResultsService.prototype, 'getTestResults');
-        getTestResultsSpy.mockResolvedValue(testResults);
+        getTestResultsSpy.mockResolvedValue(testResults as TestResultSchema[]);
         const svc = new TestResultsService(new (jest.fn())());
-        const output: ITestResult[] = await svc.getRecentTestResultsByTesterStaffId('abc123', '');
+        const output: TestResultSchema[] = await svc.getRecentTestResultsByTesterStaffId('abc123', '');
         expect(getTestResultsSpy.mock.calls).toHaveLength(1);
         expect(getTestResultsSpy.mock.calls[0][0].testerStaffId).toEqual('abc123');
         expect(getTestResultsSpy.mock.calls[0][0].toDateTime.split('.')[0]).toEqual(
@@ -37,7 +37,7 @@ describe('Test Results Service', () => {
     });
     describe('when one or more testers do not have recent tests', () => {
       it('returns undefined for those users', async () => {
-        let output: ITestResult[];
+        let output: TestResultSchema[];
         const getTestResultsSpy = jest.spyOn(TestResultsService.prototype, 'getTestResults');
         // @ts-ignore
         getTestResultsSpy.mockResolvedValue(undefined);

--- a/tests/unit/activityService.unitTest.ts
+++ b/tests/unit/activityService.unitTest.ts
@@ -5,7 +5,7 @@ import { wrapLambdaResponse } from '../util/responseUtils';
 import activitiesResponse from '../resources/activities-response.json';
 import testActivities from '../resources/testActivities.json';
 import dateMock from '../util/dateMockUtils';
-import { ACTIVITY_TYPE } from '../../src/utils/Enums';
+import { ActivityType } from "@dvsa/cvs-type-definitions/types/v1/enums/activityType.enum";
 
 describe('Activity Service', () => {
   afterEach(() => {
@@ -31,7 +31,7 @@ describe('Activity Service', () => {
       jest.spyOn(ActivityService.prototype, 'getActivities').mockImplementation(getActivitiesMock);
 
       const svc = new ActivityService(null as unknown as LambdaService);
-      await svc.getActivitiesList(ACTIVITY_TYPE.VISIT, expectedToStartTime);
+      await svc.getActivitiesList(ActivityType.VISIT, expectedToStartTime);
       expect(getActivitiesMock.mock.calls[0][0]).toEqual({
         fromStartTime: expectedTime,
         isOpen: true,
@@ -50,7 +50,7 @@ describe('Activity Service', () => {
       jest.spyOn(ActivityService.prototype, 'getActivities').mockImplementation(getActivitiesMock);
 
       const svc = new ActivityService(null as unknown as LambdaService);
-      await svc.getActivitiesList(ACTIVITY_TYPE.WAIT, expectedToStartTime, 'abc123');
+      await svc.getActivitiesList(ActivityType.WAIT, expectedToStartTime, 'abc123');
       expect(getActivitiesMock.mock.calls[0][0]).toEqual({
         fromStartTime: expectedToStartTime,
         isOpen: false,


### PR DESCRIPTION
## Implement types-definition into scheduled-ops service

scheduled-ops service does not currently use the type-definitions package and instead creates its own object for test-results and  activities

[CB2-12694](https://dvsa.atlassian.net/browse/CB2-12694)

## Checklist

- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
